### PR TITLE
Remove lifetime bounds in higher-ranked lifetimes

### DIFF
--- a/rhusics-ecs/src/collide/systems/basic.rs
+++ b/rhusics-ecs/src/collide/systems/basic.rs
@@ -78,7 +78,7 @@ where
     Y: Default + Send + Sync + 'static,
     B: Bound<Point = P::Point> + Send + Sync + 'static + Union<B, Output = B> + Clone,
     D: HasBound<Bound = B> + From<(Entity, B)> + GetId<Entity>,
-    for<'b: 'a> &'b T::Storage: Join<Type = &'b T>,
+    for<'b> &'b T::Storage: Join<Type = &'b T>,
 {
     type SystemData = (
         Entities<'a>,

--- a/rhusics-ecs/src/collide/systems/spatial_collision.rs
+++ b/rhusics-ecs/src/collide/systems/spatial_collision.rs
@@ -101,7 +101,7 @@ where
     P::Point: Debug + Send + Sync + 'static,
     T: Component + Clone + Debug + Transform<P::Point> + Send + Sync + 'static,
     Y: Default + Send + Sync + 'static,
-    for<'b: 'a> &'b T::Storage: Join<Type = &'b T>,
+    for<'b> &'b T::Storage: Join<Type = &'b T>,
     D: Send + Sync + 'static + TreeValue<Bound = B> + HasBound<Bound = B> + GetId<Entity>,
 {
     type SystemData = (
@@ -160,7 +160,7 @@ where
     T: Component + Transform<P::Point> + Send + Sync + Clone + 'static,
     Y: Default + Send + Sync + 'static,
     B: Bound<Point = P::Point> + Send + Sync + 'static + Union<B, Output = B> + Clone,
-    for<'b: 'a> &'b T::Storage: Join<Type = &'b T>,
+    for<'b> &'b T::Storage: Join<Type = &'b T>,
 {
     fn get_broad_data(&self) -> Vec<D> {
         Vec::default()

--- a/rhusics-ecs/src/collide/systems/spatial_sort.rs
+++ b/rhusics-ecs/src/collide/systems/spatial_sort.rs
@@ -68,7 +68,7 @@ where
     <P::Point as EuclideanSpace>::Diff: Debug + Send + Sync,
     T: Component + Clone + Debug + Transform<P::Point> + Send + Sync,
     Y: Default + Send + Sync + 'static,
-    for<'b: 'a> &'b T::Storage: Join<Type = &'b T>,
+    for<'b> &'b T::Storage: Join<Type = &'b T>,
     D: Send + Sync + 'static + TreeValue<Bound = B> + From<(Entity, B)>,
 {
     type SystemData = (


### PR DESCRIPTION
Those bounds are ignored by the compiler, and will trigger an error once https://github.com/rust-lang/rust/pull/48326 lands. According to crater, this is the only crate using these bounds. This patch should make the crate work on nightly again.

However, I have been unable to compile the crate even with nightly 2018-02-25, which does not include the change mentioned above. So, I couldn't compile-test this PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rustgd/rhusics/62)
<!-- Reviewable:end -->
