### PR TITLE
Bump specs version to 0.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### Unreleased
+
+- Update specs version to 0.12
+
 ### v0.4
 
 - Update to new version of collision:

--- a/rhusics-core/Cargo.toml
+++ b/rhusics-core/Cargo.toml
@@ -15,7 +15,7 @@ keywords = ["gamedev", "cgmath", "specs", "physics"]
 cgmath = "0.16"
 collision = { version = "0.18" }
 rhusics-transform = { version = "0.3.0", path = "../rhusics-transform" }
-specs = { version = "0.11", optional = true }
+specs = { version = "0.12", optional = true }
 serde = { version = "1.0", optional = true, features = ["derive"]}
 
 [target.'cfg(feature = "serde")'.dependencies]

--- a/rhusics-ecs/Cargo.toml
+++ b/rhusics-ecs/Cargo.toml
@@ -16,7 +16,7 @@ cgmath = "0.16"
 collision = { version = "0.18" }
 failure = "0.1"
 rhusics-core = { version = "0.4.0", path = "../rhusics-core", features = ["specs"] }
-specs = { version = "0.11" }
+specs = { version = "0.12" }
 shred = { version = "0.7" }
 shred-derive = { version = "0.5" }
 shrev = { version = "1.0" }
@@ -26,7 +26,7 @@ serde = { version = "1.0", optional = true, features = ["derive"]}
 cgmath = { version = "0.16", features = ["serde"] }
 collision = { version = "0.18", features = ["serde"] }
 rhusics-core = { version = "0.4.0", path = "../rhusics-core", features = ["specs", "serde"] }
-specs = { version = "0.11", features = ["serde"] }
+specs = { version = "0.12", features = ["serde"] }
 
 [[example]]
 name = "basic2d"

--- a/rhusics-ecs/examples/basic2d.rs
+++ b/rhusics-ecs/examples/basic2d.rs
@@ -6,7 +6,7 @@ extern crate specs;
 
 use cgmath::{Point2, Rad, Rotation2, Transform};
 use shrev::EventChannel;
-use specs::prelude::{RunNow, World};
+use specs::prelude::{Builder, RunNow, World};
 
 use rhusics_core::Pose;
 use rhusics_ecs::collide2d::{BasicCollisionSystem2, BodyPose2, BroadBruteForce2, CollisionMode,

--- a/rhusics-ecs/examples/basic3d.rs
+++ b/rhusics-ecs/examples/basic3d.rs
@@ -6,7 +6,7 @@ extern crate specs;
 
 use cgmath::{Point3, Quaternion, Rad, Rotation3, Transform};
 use shrev::EventChannel;
-use specs::prelude::{RunNow, World};
+use specs::prelude::{Builder, RunNow, World};
 
 use rhusics_core::Pose;
 use rhusics_ecs::collide3d::{BasicCollisionSystem3, BodyPose3, BroadBruteForce3, CollisionMode,
@@ -30,7 +30,8 @@ pub fn main() {
             CollisionMode::Discrete,
             Cuboid::new(10., 10., 10.).into(),
         ))
-        .with(BodyPose3::<f32>::one());
+        .with(BodyPose3::<f32>::one())
+        .build();
 
     world
         .create_entity()
@@ -42,7 +43,8 @@ pub fn main() {
         .with(BodyPose3::<f32>::new(
             Point3::new(3., 2., 0.),
             Quaternion::from_angle_z(Rad(0.)),
-        ));
+        ))
+        .build();
 
     system.run_now(&world.res);
     println!(

--- a/rhusics-ecs/examples/spatial2d.rs
+++ b/rhusics-ecs/examples/spatial2d.rs
@@ -9,7 +9,7 @@ use cgmath::{Point2, Rad, Rotation2, Transform, Vector2};
 use collision::Ray2;
 use collision::dbvt::query_ray_closest;
 use shrev::EventChannel;
-use specs::prelude::{ReadExpect, System, World};
+use specs::prelude::{Builder, ReadExpect, System, World};
 
 use rhusics_core::{Pose, RigidBody};
 use rhusics_ecs::WithRigidBody;

--- a/rhusics-ecs/examples/spatial3d.rs
+++ b/rhusics-ecs/examples/spatial3d.rs
@@ -9,7 +9,7 @@ use cgmath::{Point3, Quaternion, Rad, Rotation3, Transform, Vector3};
 use collision::Ray3;
 use collision::dbvt::query_ray_closest;
 use shrev::EventChannel;
-use specs::prelude::{ReadExpect, System, World};
+use specs::prelude::{Builder, ReadExpect, System, World};
 
 use rhusics_core::{Pose, RigidBody};
 use rhusics_ecs::WithRigidBody;

--- a/rhusics-ecs/src/physics/resources.rs
+++ b/rhusics-ecs/src/physics/resources.rs
@@ -2,7 +2,7 @@ use std::marker;
 
 use cgmath::{BaseFloat, EuclideanSpace, Rotation, VectorSpace, Zero};
 use collision::Bound;
-use specs::prelude::{Component, Entity, EntityBuilder, SystemData, World, WriteStorage};
+use specs::prelude::{Builder, Component, Entity, EntityBuilder, SystemData, World, WriteStorage};
 use specs::error::Error as SpecsError;
 
 use core::{CollisionShape, ForceAccumulator, Mass, NextFrame, PhysicsTime, Pose, Primitive,


### PR DESCRIPTION
Mixing these specs versions causes `SystemData` struct issues and incompatible trait implementations.
Fixes compatibility issues with Amethyst@0.8.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rustgd/rhusics/81)
<!-- Reviewable:end -->
