### PR TITLE
Implement `WithPhysics` for every `Builder`

### DIFF
--- a/rhusics-ecs/Cargo.toml
+++ b/rhusics-ecs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rhusics-ecs"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["Simon Rönnberg <seamonr@gmail.com>"]
 repository = "https://github.com/rustgd/rhusics.git"
 homepage = "https://github.com/rustgd/rhusics.git"

--- a/rhusics-ecs/src/physics/resources.rs
+++ b/rhusics-ecs/src/physics/resources.rs
@@ -3,7 +3,7 @@ use std::marker;
 use cgmath::{BaseFloat, EuclideanSpace, Rotation, VectorSpace, Zero};
 use collision::Bound;
 use specs::error::Error as SpecsError;
-use specs::prelude::{Builder, Component, Entity, EntityBuilder, SystemData, World, WriteStorage};
+use specs::prelude::{Builder, Component, Entity, SystemData, World, WriteStorage};
 
 use core::{
     CollisionShape, ForceAccumulator, Mass, NextFrame, PhysicalEntity, PhysicsTime, Pose,
@@ -108,7 +108,7 @@ pub trait WithPhysics {
         I: Send + Sync + 'static;
 }
 
-impl<'a> WithPhysics for EntityBuilder<'a> {
+impl<U: Builder> WithPhysics for U {
     fn with_dynamic_physical_entity<P, Y, R, V, A, I, B, T>(
         self,
         shape: CollisionShape<P, T, B, Y>,


### PR DESCRIPTION
`WithPhysics` was `impl`emented for `EntityBuilder` and it was
impossible to use it with a `LazyBuilder`.  This commit fixes that by
implementing `WithPhysics` for every type that implements `Builder`,
which is (as of writing this) `EntityBuilder` and `LazyBuilder`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rustgd/rhusics/90)
<!-- Reviewable:end -->
