### PR TITLE
Update rhusics to most current cgmath, collision and approx.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Changelog
 
+### v0.8 [0.5 for rhusics-transform]
+- Update cgmath to 0.17
+- Update collision to 0.20
+- Update approx to 0.3
+- No API changes, but recompilation necessary as supporting traits changed.
+
 ### v0.7
 
 - Update specs version to 0.14

--- a/rhusics-core/Cargo.toml
+++ b/rhusics-core/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "rhusics-core"
-version = "0.7.0"
-authors = ["Simon Rönnberg <seamonr@gmail.com>"]
+version = "0.8.0"
+authors = [
+    "Simon Rönnberg <seamonr@gmail.com>",
+    "Thomas O'Dell <thomas_odell@trsolutions.biz>"
+    ]
 repository = "https://github.com/rustgd/rhusics.git"
 homepage = "https://github.com/rustgd/rhusics.git"
 
@@ -12,17 +15,15 @@ description = "Physics library for use with `specs`"
 keywords = ["gamedev", "cgmath", "specs", "physics"]
 
 [dependencies]
-cgmath = "*"
-# collision = "*"
-collision = { git = "https://github.com/rustgd/collision-rs" }
-rhusics-transform = { version = "0.4.0", path = "../rhusics-transform" }
+cgmath = "0.17"
+collision = "0.20"
+rhusics-transform = { version = "0.5.0", path = "../rhusics-transform" }
 specs = { version = "0.14", optional = true }
 serde = { version = "1.0", optional = true, features = ["derive"]}
 
 [target.'cfg(feature = "serde")'.dependencies]
 cgmath = { version = "*", features = ["serde"] }
-#collision = { version = "*", features = ["serde"] }
-collision = { git = "https://github.com/rustgd/collision-rs", features = ["serde"] }
+collision = { version = "0.20", features = ["serde"] }
 
 [dev-dependencies]
 approx = "0.3"

--- a/rhusics-core/Cargo.toml
+++ b/rhusics-core/Cargo.toml
@@ -12,15 +12,17 @@ description = "Physics library for use with `specs`"
 keywords = ["gamedev", "cgmath", "specs", "physics"]
 
 [dependencies]
-cgmath = "0.16"
-collision = { version = "0.18" }
+cgmath = "*"
+# collision = "*"
+collision = { git = "https://github.com/rustgd/collision-rs" }
 rhusics-transform = { version = "0.4.0", path = "../rhusics-transform" }
 specs = { version = "0.14", optional = true }
 serde = { version = "1.0", optional = true, features = ["derive"]}
 
 [target.'cfg(feature = "serde")'.dependencies]
-cgmath = { version = "0.16", features = ["serde"] }
-collision = { version = "0.18", features = ["serde"] }
+cgmath = { version = "*", features = ["serde"] }
+#collision = { version = "*", features = ["serde"] }
+collision = { git = "https://github.com/rustgd/collision-rs", features = ["serde"] }
 
 [dev-dependencies]
-approx = "0.1"
+approx = "0.3"

--- a/rhusics-ecs/Cargo.toml
+++ b/rhusics-ecs/Cargo.toml
@@ -12,8 +12,9 @@ description = "Physics library for use with `specs`"
 keywords = ["gamedev", "cgmath", "specs", "physics"]
 
 [dependencies]
-cgmath = "0.16"
-collision = { version = "0.18" }
+cgmath = "*"
+# collision = { version = "*" }
+collision = { version = "*", git = "https://github.com/rustgd/collision-rs" }
 failure = "0.1"
 rhusics-core = { version = "0.7.0", path = "../rhusics-core", features = ["specs"] }
 specs = { version = "0.14" }
@@ -23,8 +24,9 @@ shrev = { version = "1.0" }
 serde = { version = "1.0", optional = true, features = ["derive"]}
 
 [target.'cfg(feature = "serde")'.dependencies]
-cgmath = { version = "0.16", features = ["serde"] }
-collision = { version = "0.18", features = ["serde"] }
+cgmath = { version = "*", features = ["serde"] }
+#collision = { version = "*", features = ["serde"] }
+collision = { version = "*", features = ["serde"], git = "https://github.com/rustgd/collision-rs" }
 rhusics-core = { version = "0.7.0", path = "../rhusics-core", features = ["specs", "serde"] }
 specs = { version = "0.12", features = ["serde"] }
 

--- a/rhusics-ecs/Cargo.toml
+++ b/rhusics-ecs/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "rhusics-ecs"
-version = "0.7.1"
-authors = ["Simon Rönnberg <seamonr@gmail.com>"]
+version = "0.8.0"
+authors = [
+    "Simon Rönnberg <seamonr@gmail.com>",
+    "Thomas O'Dell <thomas_odell@trsolutions.biz>"
+    ]
 repository = "https://github.com/rustgd/rhusics.git"
 homepage = "https://github.com/rustgd/rhusics.git"
 
@@ -12,11 +15,10 @@ description = "Physics library for use with `specs`"
 keywords = ["gamedev", "cgmath", "specs", "physics"]
 
 [dependencies]
-cgmath = "*"
-# collision = { version = "*" }
-collision = { version = "*", git = "https://github.com/rustgd/collision-rs" }
+cgmath = "0.17"
+collision = { version = "0.20" }
 failure = "0.1"
-rhusics-core = { version = "0.7.0", path = "../rhusics-core", features = ["specs"] }
+rhusics-core = { version = "0.8.0", path = "../rhusics-core", features = ["specs"] }
 specs = { version = "0.14" }
 shred = { version = "0.7" }
 shred-derive = { version = "0.5" }
@@ -24,10 +26,9 @@ shrev = { version = "1.0" }
 serde = { version = "1.0", optional = true, features = ["derive"]}
 
 [target.'cfg(feature = "serde")'.dependencies]
-cgmath = { version = "*", features = ["serde"] }
-#collision = { version = "*", features = ["serde"] }
-collision = { version = "*", features = ["serde"], git = "https://github.com/rustgd/collision-rs" }
-rhusics-core = { version = "0.7.0", path = "../rhusics-core", features = ["specs", "serde"] }
+cgmath = { version = "0.17", features = ["serde"] }
+collision = { version = "0.20", features = ["serde"] }
+rhusics-core = { version = "0.8.0", path = "../rhusics-core", features = ["specs", "serde"] }
 specs = { version = "0.12", features = ["serde"] }
 
 [[example]]

--- a/rhusics-transform/Cargo.toml
+++ b/rhusics-transform/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rhusics-transform"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Simon Rönnberg <seamonr@gmail.com>"]
 repository = "https://github.com/rustgd/rhusics.git"
 homepage = "https://github.com/rustgd/rhusics.git"
@@ -12,5 +12,5 @@ description = "Physics library for use with `specs`"
 keywords = ["gamedev", "cgmath", "specs", "physics"]
 
 [dependencies]
-cgmath = "*"
-collision = { version = "*", git = "https://github.com/rustgd/collision-rs" }
+cgmath = "0.17"
+collision = { version = "0.20" }

--- a/rhusics-transform/Cargo.toml
+++ b/rhusics-transform/Cargo.toml
@@ -12,5 +12,5 @@ description = "Physics library for use with `specs`"
 keywords = ["gamedev", "cgmath", "specs", "physics"]
 
 [dependencies]
-cgmath = "0.16"
-collision = "0.18"
+cgmath = "*"
+collision = { version = "*", git = "https://github.com/rustgd/collision-rs" }


### PR DESCRIPTION
Because rhusics relies on traits produced by cgmath, collision-rs and approx, it needs to be re-released and pushed to Crates.io if those traits change.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rustgd/rhusics/91)
<!-- Reviewable:end -->
