### PR TITLE
0.9/0.5: Updated to shred 0.10 and specs 0.16; serde feature renamed …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## Changelog
 
+### v0.9 [0.5 for rhusics-transform]
+- updated shred to 0.10.
+- updated specs to 0.16, modified to new API ("World" instead of "Resources").
+- updated boxed class refs to include dyn, as requested by compiler.
+- fixed bug in toml files where was always using serde.
+- BREAKING CHANGE: use "serializable" instead of "serde" to get serialization.
+  Using just "serde" won't compile any more.
+
 ### v0.8 [0.5 for rhusics-transform]
 - Update cgmath to 0.17
 - Update collision to 0.20

--- a/rhusics-core/Cargo.toml
+++ b/rhusics-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rhusics-core"
-version = "0.8.0"
+version = "0.9.0"
 authors = [
     "Simon Rönnberg <seamonr@gmail.com>",
     "Thomas O'Dell <thomas_odell@trsolutions.biz>"
@@ -14,16 +14,16 @@ description = "Physics library for use with `specs`"
 
 keywords = ["gamedev", "cgmath", "specs", "physics"]
 
+[features]
+serializable = ["serde", "cgmath/serde", "collision/serde"]
+
 [dependencies]
 cgmath = "0.17"
 collision = "0.20"
 rhusics-transform = { version = "0.5.0", path = "../rhusics-transform" }
-specs = { version = "0.14", optional = true }
+specs = { version = "0.16", optional = true }
 serde = { version = "1.0", optional = true, features = ["derive"]}
-
-[target.'cfg(feature = "serde")'.dependencies]
-cgmath = { version = "*", features = ["serde"] }
-collision = { version = "0.20", features = ["serde"] }
 
 [dev-dependencies]
 approx = "0.3"
+serde_json = "1.0"

--- a/rhusics-core/src/body_pose.rs
+++ b/rhusics-core/src/body_pose.rs
@@ -5,7 +5,7 @@ use Pose;
 
 /// Transform component used throughout the library
 #[derive(Clone, Debug, PartialEq)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(target_feature = "serializable", derive(Serialize, Deserialize))]
 pub struct BodyPose<P, R> {
     dirty: bool,
     position: P,

--- a/rhusics-core/src/collide/broad.rs
+++ b/rhusics-core/src/collide/broad.rs
@@ -52,7 +52,7 @@ where
 /// - `B`: Bounding volume
 /// - `Y`: Collider, see `Collider` for more information
 /// - `D`: Broad phase data
-pub fn broad_collide<C, I, P, T, B, Y, D>(data: &C, broad: &mut Box<BroadPhase<D>>) -> Vec<(I, I)>
+pub fn broad_collide<C, I, P, T, B, Y, D>(data: &C, broad: &mut Box<dyn BroadPhase<D>>) -> Vec<(I, I)>
 where
     C: CollisionData<I, P, T, B, Y, D>,
     P: Primitive,

--- a/rhusics-core/src/collide/narrow.rs
+++ b/rhusics-core/src/collide/narrow.rs
@@ -184,7 +184,7 @@ fn max(left: &CollisionStrategy, right: &CollisionStrategy) -> CollisionStrategy
 /// - `D`: Broad phase data, not used here, but required for `CollisionData`
 pub fn narrow_collide<C, I, P, T, B, Y, D>(
     data: &C,
-    narrow: &Box<NarrowPhase<P, T, B, Y>>,
+    narrow: &Box<dyn NarrowPhase<P, T, B, Y>>,
     potentials: &[(I, I)],
 ) -> Vec<ContactEvent<I, P::Point>>
 where

--- a/rhusics-core/src/lib.rs
+++ b/rhusics-core/src/lib.rs
@@ -42,7 +42,7 @@ extern crate specs;
 #[macro_use]
 extern crate approx;
 
-#[cfg(feature = "serde")]
+#[cfg(feature = "serializable")]
 #[macro_use]
 extern crate serde;
 
@@ -73,7 +73,7 @@ mod physics;
 
 /// Wrapper for data computed for the next frame
 #[derive(Clone, Debug, PartialEq)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serializable", derive(Serialize, Deserialize))]
 pub struct NextFrame<T> {
     /// Wrapped value
     pub value: T,

--- a/rhusics-core/src/physics/force.rs
+++ b/rhusics-core/src/physics/force.rs
@@ -11,7 +11,7 @@ use super::PartialCrossProduct;
 /// - `F`: Force type, usually `Vector2` or `Vector3`
 /// - `T`: Torque force, usually `Scalar` or `Vector3`
 #[derive(Debug)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serializable", derive(Serialize, Deserialize))]
 pub struct ForceAccumulator<F, T> {
     force: F,
     torque: T,

--- a/rhusics-core/src/physics/mass.rs
+++ b/rhusics-core/src/physics/mass.rs
@@ -15,7 +15,7 @@ use super::{Material, Volume};
 ///
 /// - `I`: Inertia type, usually `Scalar` or `Matrix3`, see `Inertia` for more information.
 #[derive(Debug, Clone)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serializable", derive(Serialize, Deserialize))]
 pub struct Mass<S, I> {
     mass: S,
     inverse_mass: S,

--- a/rhusics-core/src/physics/mod.rs
+++ b/rhusics-core/src/physics/mod.rs
@@ -22,7 +22,7 @@ use cgmath::{BaseFloat, VectorSpace};
 
 /// Global parameters for the physics world
 #[derive(Debug, Clone)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serializable", derive(Serialize, Deserialize))]
 pub struct WorldParameters<V, S> {
     gravity: V,
     damping: S,
@@ -80,7 +80,7 @@ where
 /// The default material has density 1, such that only the volume affects its mass, and restitution
 /// 1, such that all energy is preserved in collisions.
 #[derive(Debug, Clone)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serializable", derive(Serialize, Deserialize))]
 pub struct Material {
     density: f32,
     restitution: f32,
@@ -156,7 +156,7 @@ impl Material {
 
 /// Physical entity
 #[derive(Debug, Clone)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serializable", derive(Serialize, Deserialize))]
 pub struct PhysicalEntity<S> {
     material: Material,
     gravity_scale: S,

--- a/rhusics-core/src/physics/velocity.rs
+++ b/rhusics-core/src/physics/velocity.rs
@@ -12,7 +12,7 @@ use Pose;
 /// - `L`: Linear velocity, usually `Vector2` or `Vector3`
 /// - `A`: Angular velocity, usually `Scalar` or `Vector3`
 #[derive(Debug, Clone, PartialEq)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serializable", derive(Serialize, Deserialize))]
 pub struct Velocity<L, A> {
     linear: L,
     angular: A,

--- a/rhusics-ecs/Cargo.toml
+++ b/rhusics-ecs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rhusics-ecs"
-version = "0.8.0"
+version = "0.9.0"
 authors = [
     "Simon Rönnberg <seamonr@gmail.com>",
     "Thomas O'Dell <thomas_odell@trsolutions.biz>"
@@ -14,22 +14,19 @@ description = "Physics library for use with `specs`"
 
 keywords = ["gamedev", "cgmath", "specs", "physics"]
 
+[features]
+serializable = ["serde", "cgmath/serde", "collision/serde", "rhusics-core/serializable"]
+
 [dependencies]
 cgmath = "0.17"
 collision = { version = "0.20" }
 failure = "0.1"
-rhusics-core = { version = "0.8.0", path = "../rhusics-core", features = ["specs"] }
-specs = { version = "0.14" }
-shred = { version = "0.7" }
-shred-derive = { version = "0.5" }
-shrev = { version = "1.0" }
-serde = { version = "1.0", optional = true, features = ["derive"]}
-
-[target.'cfg(feature = "serde")'.dependencies]
-cgmath = { version = "0.17", features = ["serde"] }
-collision = { version = "0.20", features = ["serde"] }
-rhusics-core = { version = "0.8.0", path = "../rhusics-core", features = ["specs", "serde"] }
-specs = { version = "0.12", features = ["serde"] }
+rhusics-core = { version = "0.9.0", path = "../rhusics-core", features = ["specs"] }
+specs = { version = "0.16" }
+shred = { version = "0.10" }
+shred-derive = { version = "0.6" }
+shrev = { version = "1.1" }
+serde = { version = "1.0", optional = true, features = ["derive"] }
 
 [[example]]
 name = "basic2d"

--- a/rhusics-ecs/examples/basic2d.rs
+++ b/rhusics-ecs/examples/basic2d.rs
@@ -6,7 +6,7 @@ extern crate specs;
 
 use cgmath::{Point2, Rad, Rotation2, Transform};
 use shrev::EventChannel;
-use specs::prelude::{Builder, RunNow, World};
+use specs::prelude::{Builder, RunNow, World, WorldExt};
 
 use rhusics_core::Pose;
 use rhusics_ecs::collide2d::{
@@ -20,7 +20,7 @@ pub fn main() {
     let mut system = BasicCollisionSystem2::<f32, BodyPose2<f32>, ()>::new()
         .with_broad_phase(BroadBruteForce2::default())
         .with_narrow_phase(GJK2::new());
-    system.setup(&mut world.res);
+    system.setup(&mut world);
 
     let mut reader_1 = world
         .write_resource::<EventChannel<ContactEvent2<f32>>>()
@@ -46,7 +46,7 @@ pub fn main() {
             Rotation2::from_angle(Rad(0.)),
         )).build();
 
-    system.run_now(&world.res);
+    system.run_now(&world);
     println!(
         "Contacts: {:?}",
         world

--- a/rhusics-ecs/examples/basic3d.rs
+++ b/rhusics-ecs/examples/basic3d.rs
@@ -6,7 +6,7 @@ extern crate specs;
 
 use cgmath::{Point3, Quaternion, Rad, Rotation3, Transform};
 use shrev::EventChannel;
-use specs::prelude::{Builder, RunNow, World};
+use specs::prelude::{Builder, RunNow, World, WorldExt};
 
 use rhusics_core::Pose;
 use rhusics_ecs::collide3d::{
@@ -19,7 +19,7 @@ pub fn main() {
     let mut system = BasicCollisionSystem3::<f32, BodyPose3<f32>, ()>::new()
         .with_broad_phase(BroadBruteForce3::default())
         .with_narrow_phase(GJK3::new());
-    system.setup(&mut world.res);
+    system.setup(&mut world);
 
     let mut reader_1 = world
         .write_resource::<EventChannel<ContactEvent3<f32>>>()
@@ -45,7 +45,7 @@ pub fn main() {
             Quaternion::from_angle_z(Rad(0.)),
         )).build();
 
-    system.run_now(&world.res);
+    system.run_now(&world);
     println!(
         "Contacts: {:?}",
         world

--- a/rhusics-ecs/examples/spatial2d.rs
+++ b/rhusics-ecs/examples/spatial2d.rs
@@ -9,7 +9,7 @@ use cgmath::{Point2, Rad, Rotation2, Transform, Vector2};
 use collision::dbvt::query_ray_closest;
 use collision::Ray2;
 use shrev::EventChannel;
-use specs::prelude::{Builder, ReadExpect, System, World};
+use specs::prelude::{Builder, ReadExpect, System, World, WorldExt};
 
 use rhusics_core::{PhysicalEntity, Pose};
 use rhusics_ecs::physics2d::{
@@ -43,12 +43,12 @@ pub fn main() {
     let mut next_frame = NextFrameSetupSystem2::<f32, BodyPose2<f32>>::new();
     let mut contact_resolution = ContactResolutionSystem2::<f32, BodyPose2<f32>>::new();
 
-    sort.setup(&mut world.res);
-    collide.setup(&mut world.res);
-    raycast.setup(&mut world.res);
-    impulse_solver.setup(&mut world.res);
-    next_frame.setup(&mut world.res);
-    contact_resolution.setup(&mut world.res);
+    sort.setup(&mut world);
+    collide.setup(&mut world);
+    raycast.setup(&mut world);
+    impulse_solver.setup(&mut world);
+    next_frame.setup(&mut world);
+    contact_resolution.setup(&mut world);
 
     world
         .create_entity()
@@ -82,8 +82,8 @@ pub fn main() {
 
     {
         use specs::prelude::RunNow;
-        sort.run_now(&world.res);
-        collide.run_now(&world.res);
+        sort.run_now(&world);
+        collide.run_now(&world);
 
         println!(
             "Contacts: {:?}",
@@ -93,9 +93,9 @@ pub fn main() {
                 .collect::<Vec<_>>()
         );
 
-        raycast.run_now(&world.res);
-        impulse_solver.run_now(&world.res);
-        next_frame.run_now(&world.res);
-        contact_resolution.run_now(&world.res);
+        raycast.run_now(&world);
+        impulse_solver.run_now(&world);
+        next_frame.run_now(&world);
+        contact_resolution.run_now(&world);
     }
 }

--- a/rhusics-ecs/examples/spatial3d.rs
+++ b/rhusics-ecs/examples/spatial3d.rs
@@ -9,7 +9,7 @@ use cgmath::{Point3, Quaternion, Rad, Rotation3, Transform, Vector3};
 use collision::dbvt::query_ray_closest;
 use collision::Ray3;
 use shrev::EventChannel;
-use specs::prelude::{Builder, ReadExpect, System, World};
+use specs::prelude::{Builder, ReadExpect, System, World, WorldExt};
 
 use rhusics_core::{PhysicalEntity, Pose};
 use rhusics_ecs::physics3d::{
@@ -42,12 +42,12 @@ pub fn main() {
     let mut next_frame = NextFrameSetupSystem3::<f32, BodyPose3<f32>>::new();
     let mut contact_resolution = ContactResolutionSystem3::<f32, BodyPose3<f32>>::new();
 
-    sort.setup(&mut world.res);
-    collide.setup(&mut world.res);
-    raycast.setup(&mut world.res);
-    impulse_solver.setup(&mut world.res);
-    next_frame.setup(&mut world.res);
-    contact_resolution.setup(&mut world.res);
+    sort.setup(&mut world);
+    collide.setup(&mut world);
+    raycast.setup(&mut world);
+    impulse_solver.setup(&mut world);
+    next_frame.setup(&mut world);
+    contact_resolution.setup(&mut world);
 
     world
         .create_entity()
@@ -80,8 +80,8 @@ pub fn main() {
         .register_reader();
     {
         use specs::prelude::RunNow;
-        sort.run_now(&world.res);
-        collide.run_now(&world.res);
+        sort.run_now(&world);
+        collide.run_now(&world);
         println!(
             "Contacts: {:?}",
             world
@@ -89,10 +89,10 @@ pub fn main() {
                 .read(&mut reader_1)
                 .collect::<Vec<_>>()
         );
-        raycast.run_now(&world.res);
+        raycast.run_now(&world);
 
-        impulse_solver.run_now(&world.res);
-        next_frame.run_now(&world.res);
-        contact_resolution.run_now(&world.res);
+        impulse_solver.run_now(&world);
+        next_frame.run_now(&world);
+        contact_resolution.run_now(&world);
     }
 }

--- a/rhusics-ecs/src/collide/systems/basic.rs
+++ b/rhusics-ecs/src/collide/systems/basic.rs
@@ -37,8 +37,8 @@ where
     P: Primitive,
     B: Bound,
 {
-    narrow: Option<Box<NarrowPhase<P, T, B, Y>>>,
-    broad: Option<Box<BroadPhase<D>>>,
+    narrow: Option<Box<dyn NarrowPhase<P, T, B, Y>>>,
+    broad: Option<Box<dyn BroadPhase<D>>>,
 }
 
 impl<P, T, D, B, Y> BasicCollisionSystem<P, T, D, B, Y>

--- a/rhusics-ecs/src/collide/systems/spatial_collision.rs
+++ b/rhusics-ecs/src/collide/systems/spatial_collision.rs
@@ -6,7 +6,7 @@ use collision::dbvt::{DynamicBoundingVolumeTree, TreeValue};
 use collision::prelude::*;
 use shrev::EventChannel;
 use specs::prelude::{
-    BitSet, Component, ComponentEvent, Entities, Entity, Join, ReadStorage, ReaderId, Resources,
+    BitSet, Component, ComponentEvent, Entities, Entity, Join, ReadStorage, ReaderId, World,
     System, Tracked, Write,
 };
 
@@ -45,8 +45,8 @@ where
     P: Primitive,
     B: Bound,
 {
-    narrow: Option<Box<NarrowPhase<P, T, B, Y>>>,
-    broad: Option<Box<BroadPhase<D>>>,
+    narrow: Option<Box<dyn NarrowPhase<P, T, B, Y>>>,
+    broad: Option<Box<dyn BroadPhase<D>>>,
     dirty: BitSet,
     pose_reader: Option<ReaderId<ComponentEvent>>,
     next_pose_reader: Option<ReaderId<ComponentEvent>>,
@@ -172,7 +172,7 @@ where
         ));
     }
 
-    fn setup(&mut self, res: &mut Resources) {
+    fn setup(&mut self, res: &mut World) {
         use specs::prelude::{SystemData, WriteStorage};
         Self::SystemData::setup(res);
         let mut poses = WriteStorage::<T>::fetch(res);

--- a/rhusics-ecs/src/collide/systems/spatial_sort.rs
+++ b/rhusics-ecs/src/collide/systems/spatial_sort.rs
@@ -7,7 +7,7 @@ use cgmath::BaseFloat;
 use collision::dbvt::{DynamicBoundingVolumeTree, TreeValue};
 use collision::prelude::*;
 use specs::prelude::{
-    BitSet, Component, ComponentEvent, Entities, Entity, Join, ReadStorage, ReaderId, Resources,
+    BitSet, Component, ComponentEvent, Entities, Entity, Join, ReadStorage, ReaderId, World,
     System, Tracked, Write, WriteStorage,
 };
 
@@ -181,7 +181,7 @@ where
         tree.do_refit();
     }
 
-    fn setup(&mut self, res: &mut Resources) {
+    fn setup(&mut self, res: &mut World) {
         use specs::prelude::SystemData;
         Self::SystemData::setup(res);
         let mut poses = WriteStorage::<T>::fetch(res);

--- a/rhusics-ecs/src/lib.rs
+++ b/rhusics-ecs/src/lib.rs
@@ -33,17 +33,15 @@
 
 extern crate cgmath;
 extern crate collision;
-#[macro_use]
 extern crate failure;
 extern crate rhusics_core as core;
 extern crate shred;
 extern crate shrev;
 extern crate specs;
 
-#[macro_use]
 extern crate shred_derive;
 
-#[cfg(feature = "serde")]
+#[cfg(feature = "serializable")]
 #[macro_use]
 extern crate serde;
 

--- a/rhusics-ecs/src/physics/resources.rs
+++ b/rhusics-ecs/src/physics/resources.rs
@@ -3,12 +3,13 @@ use std::marker;
 use cgmath::{BaseFloat, EuclideanSpace, Rotation, VectorSpace, Zero};
 use collision::Bound;
 use specs::error::Error as SpecsError;
-use specs::prelude::{Builder, Component, Entity, SystemData, World, WriteStorage};
+use specs::prelude::{Builder, Component, Entity, SystemData, World, WriteStorage, ResourceId};
 
 use core::{
     CollisionShape, ForceAccumulator, Mass, NextFrame, PhysicalEntity, PhysicsTime, Pose,
     Primitive, Velocity,
 };
+use failure::Fail;
 
 /// Time step resource
 ///
@@ -16,7 +17,7 @@ use core::{
 ///
 /// - `S`: Scalar
 #[derive(Debug)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serializable", derive(Serialize, Deserialize))]
 pub struct DeltaTime<S>
 where
     S: BaseFloat,
@@ -231,7 +232,7 @@ where
 {
     /// Extract physical entity storage from `World`
     pub fn new(world: &'a World) -> Self {
-        Self::fetch(&world.res)
+        Self::fetch(&world)
     }
 
     /// Setup static physical entity for given entity.
@@ -278,7 +279,7 @@ mod tests {
     use collision::primitive::Primitive3;
     use collision::Aabb3;
     use core::collide3d::BodyPose3;
-    use specs::prelude::{SystemData, World};
+    use specs::prelude::{SystemData, World, WorldExt};
 
     type PhysicalEntityPartsTest<'a> = PhysicalEntityParts<
         'a,
@@ -295,7 +296,7 @@ mod tests {
     #[test]
     fn test() {
         let mut world = World::new();
-        PhysicalEntityPartsTest::setup(&mut world.res);
+        PhysicalEntityPartsTest::setup(&mut world);
         PhysicalEntityPartsTest::new(&world);
     }
 }

--- a/rhusics-ecs/src/physics/systems/contact_resolution.rs
+++ b/rhusics-ecs/src/physics/systems/contact_resolution.rs
@@ -9,7 +9,7 @@ use core::{
 };
 use core::{NextFrame, Pose};
 use shrev::{EventChannel, ReaderId};
-use specs::prelude::{Component, Entity, Read, ReadStorage, Resources, System, WriteStorage};
+use specs::prelude::{Component, Entity, Read, ReadStorage, World, System, WriteStorage};
 
 /// Do single contact, forward resolution.
 ///
@@ -127,7 +127,7 @@ where
         }
     }
 
-    fn setup(&mut self, res: &mut Resources) {
+    fn setup(&mut self, res: &mut World) {
         use specs::prelude::SystemData;
         Self::SystemData::setup(res);
         self.contact_reader = Some(


### PR DESCRIPTION
Cleanup to get this up-to-date with the specs world.
- updated shred to 0.10.
- updated specs to 0.16, modified to new API ("World" instead of "Resources").
- updated boxed class refs to include dyn, as requested by compiler.
- fixed bug in toml files where was always using serde.
- BREAKING CHANGE: use "serializable" instead of "serde" to get serialization.
  Using just "serde" won't compile any more.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rustgd/rhusics/93)
<!-- Reviewable:end -->
